### PR TITLE
Fix default port to 13105

### DIFF
--- a/cmd/dash-home/main.go
+++ b/cmd/dash-home/main.go
@@ -59,7 +59,7 @@ func main() {
 	// Initialize HTTP Server...
 	httpPort := os.Getenv("HTTP_PORT")
 	if len(httpPort) == 0 {
-		httpPort = "8080"
+		httpPort = "13105"
 	}
 	if err := startHTTPServer(httpPort, agent, room, controller); err != nil {
 		panic(err)


### PR DESCRIPTION
# Desc.
Fix default port to 13105 from 8080.

# Why?
In many cases, 8080 has reserved some webapp and proxy.

# What meaning of '13105' ?
* 0xD, 0xA, 0x5 (S). (H is not in hexadecimal...)